### PR TITLE
Remove 'Float80' from ARM builds

### DIFF
--- a/Sources/SwiftZ3/SortKinds/Numeric/FloatingPoint/Float80+FloatingSort.swift
+++ b/Sources/SwiftZ3/SortKinds/Numeric/FloatingPoint/Float80+FloatingSort.swift
@@ -1,4 +1,4 @@
-#if os(macOS) || os(Linux)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 extension Float80: FloatingSort {
     /// Returns an 80-bit FloatingPoint sort.
     public static func getSort(_ context: Z3Context) -> Z3Sort {


### PR DESCRIPTION
Float80 isn't available on ARM architectures. This pull request changes the `#ifdef` macros around Float80 to check for ARM architectures as well as OS.

This pull request is based on the fix used here:
https://github.com/leoture/MockSwift/pull/120/commits/3c0eadebbb185a73fe44133ddbcc453e41ced7d2

"Float80 is available on Intel when the target system supports an 80-bit long double type, and unavailable on Apple silicon."
https://developer.apple.com/documentation/swift/float80